### PR TITLE
feat: add Gemini 3 model shortcuts and auto router support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2025-12-28
+
+### Added
+- **Gemini 3 model shortcuts**: New aliases `3-pro` and `3-flash` for the latest Gemini 3 preview models (`gemini-3-pro-preview`, `gemini-3-flash-preview`).
+- **Model router support**: Use `auto` to let Gemini CLI's model router choose the optimal model for each task.
+
+### Changed
+- Updated `_normalize_model_name()` documentation to reflect all supported model aliases.
+
 ## [1.0.5] - 2025-08-26
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gemini-bridge"
-version = "1.1.1"
+version = "1.2.0"
 description = "Lightweight MCP server bridging Claude Code to Google's Gemini AI via official CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,5 +2,5 @@
 
 from .mcp_server import main
 
-__version__ = "1.1.1"
+__version__ = "1.2.0"
 __all__ = ["main"]

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Gemini MCP Server - Simple CLI Bridge
-Version 1.1.1
+Version 1.2.0
 A minimal MCP server to interface with Gemini AI via the gemini CLI.
 Created by @shelakh/elyin
 """
@@ -32,20 +32,36 @@ def _normalize_model_name(model: Optional[str]) -> str:
     Defaults to gemini-2.5-flash when not provided or unrecognized.
 
     Accepted forms:
-    - "flash", "2.5-flash", "gemini-2.5-flash"
-    - "pro", "2.5-pro", "gemini-2.5-pro"
+    - "flash", "2.5-flash", "gemini-2.5-flash" -> gemini-2.5-flash
+    - "pro", "2.5-pro", "gemini-2.5-pro" -> gemini-2.5-pro
+    - "3-pro", "gemini-3-pro", "gemini-3-pro-preview" -> gemini-3-pro-preview
+    - "3-flash", "gemini-3-flash", "gemini-3-flash-preview" -> gemini-3-flash-preview
+    - "auto" -> auto (model router, lets CLI choose optimal model)
     """
     if not model:
         return "gemini-2.5-flash"
     value = model.strip().lower()
-    # Common short aliases
+
+    # Gemini 2.5 aliases
     if value in {"flash", "2.5-flash", "gemini-2.5-flash"}:
         return "gemini-2.5-flash"
     if value in {"pro", "2.5-pro", "gemini-2.5-pro"}:
         return "gemini-2.5-pro"
-    # If the caller passed a full model name, keep it
+
+    # Gemini 3 aliases (preview models)
+    if value in {"3-pro", "gemini-3-pro", "gemini-3-pro-preview"}:
+        return "gemini-3-pro-preview"
+    if value in {"3-flash", "gemini-3-flash", "gemini-3-flash-preview"}:
+        return "gemini-3-flash-preview"
+
+    # Model router (let CLI choose best model)
+    if value == "auto":
+        return "auto"
+
+    # Pass through any other gemini-* model name
     if value.startswith("gemini-"):
         return value
+
     # Fallback to flash for anything else
     return "gemini-2.5-flash"
 


### PR DESCRIPTION
## Summary
- Add model shortcuts for Gemini 3 preview models (`3-pro`, `3-flash`)
- Add `auto` model router support to let Gemini CLI choose optimal model
- Bump version to 1.2.0

## New Model Aliases

| Input | Output |
|-------|--------|
| `3-pro`, `gemini-3-pro` | `gemini-3-pro-preview` |
| `3-flash`, `gemini-3-flash` | `gemini-3-flash-preview` |
| `auto` | `auto` (model router) |

## Changes
- `src/mcp_server.py`: Updated `_normalize_model_name()` with new aliases
- `src/__init__.py`: Version bump to 1.2.0
- `pyproject.toml`: Version bump to 1.2.0
- `CHANGELOG.md`: Added 1.2.0 release notes

## Test plan
- [x] All existing model aliases still work (`flash`, `pro`, etc.)
- [x] New Gemini 3 aliases work (`3-pro`, `3-flash`)
- [x] Model router alias works (`auto`)
- [x] Fallback behavior unchanged for unknown models